### PR TITLE
Fix when neither --delimiter nor --tab is provided. New default: ','.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 *.pyc
 *.egg-info
+*~

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,5 @@ Patches and Suggestions
 ```````````````````````
 
 - Christine Doig
+- Yaiza Rubio
+- Félix Brezo

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+1.0.2 (2016-01-17)
+++++++++++++++++++
+- Fix when neither --delimiter nor --tab is provided. New default: ','.
+- Added *~ to .gitignore
+
 1.0.1 (2015-06-02)
 ++++++++++++++++++
 - Add option to stream from stdin

--- a/csv2es.py
+++ b/csv2es.py
@@ -26,7 +26,7 @@ from pyelasticsearch import IndexAlreadyExistsError
 from retrying import retry
 
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 thread_local = local()
 
 
@@ -111,8 +111,9 @@ def sanitize_delimiter(delimiter, is_tab):
     """
     Return a single character delimiter from the given (possibly unicode)
     string. If is_tab is True, always return a single tab. If delimiter is None
-    then return None. Raise an Exception if the delimiter can't be converted to
-    a single character.
+    previously None was returned in previous versions, but a ',' is preferred 
+    here to match the examples in the README. Raise an Exception if the 
+    delimiter can't be converted to a single character.
 
     Why is this so complicated with some kind of special artisan tab handling?
     Well, passing in a tab character as a delimiter from the commandline as
@@ -130,7 +131,8 @@ def sanitize_delimiter(delimiter, is_tab):
         return str('\t')
 
     if delimiter is None:
-        return None
+        # Modified from None to ',' in 1.0.2
+        return str(',')
     else:
         d = str(delimiter)
         if len(d) == 1:


### PR DESCRIPTION
A minor change in the sanitize_delimiter(delimiter, is_tab) function to change a None return by a ','. 