### PR TITLE
New options for field name cleanup, tags, date field parsing to epoch_millis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 *.pyc
 *.egg-info
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ python:
 
 install:
   - pip install .
+  - pip install python-dateutil
 
 script: python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 csv2es
 =========================
 
+--------
+IMPORTANT: This is a FORK of the original project. See this link for issues this fork addresses: https://github.com/rholder/csv2es/pulls/bitsofinfo
+--------
+
 .. image:: https://img.shields.io/pypi/v/csv2es.svg
     :target: https://pypi.python.org/pypi/csv2es
 

--- a/csv2es.py
+++ b/csv2es.py
@@ -27,6 +27,8 @@ from pyelasticsearch import ElasticHttpNotFoundError
 from pyelasticsearch import IndexAlreadyExistsError
 from retrying import retry
 from dateutil import parser
+from datetime import timedelta
+from pprint import pprint
 
 __version__ = '1.0.1'
 thread_local = local()
@@ -81,7 +83,12 @@ def documents_from_file(es, filename, delimiter, quiet, csv_clean_fieldnames, cs
 
                     if date_val_str:
                         date_obj = parser.parse(date_val_str.strip())
-                        row[csv_date_field] = int(calendar.timegm(date_obj.timetuple()) + (csv_date_field_gmt_offset * (3600))) * 1000
+                        pprint(date_obj)
+                        corrected_offset = (csv_date_field_gmt_offset * -1)
+                        date_obj = date_obj + timedelta(hours=corrected_offset)
+                        pprint(date_obj)
+                        row[csv_date_field] = int(calendar.timegm(date_obj.timetuple())) * 1000
+                        pprint(row)
 
                 count += 1
                 if count % 10000 == 0:

--- a/csv2es.py
+++ b/csv2es.py
@@ -66,11 +66,11 @@ def documents_from_file(es, filename, delimiter, quiet, csv_date_field, csv_date
             for row in reader:
 
                 # parse csv_date_field into elasticsearch compatible epoch_millis
-                if csv_date_field
+                if csv_date_field:
                     date_val_str = row[csv_date_field]
-                    if date_val_str
+                    if date_val_str:
                         date_obj = parser.parse(date_val_str.strip())
-                        if not csv_date_field_gmt_offset
+                        if not csv_date_field_gmt_offset:
                             csv_date_field_gmt_offset = 0
                         row[csv_date_field] = int(calendar.timegm(date_obj) - csv_date_field_gmt_offset) * 1000
 

--- a/csv2es.py
+++ b/csv2es.py
@@ -16,6 +16,7 @@ import csv
 import json
 import sys
 import calendar
+from pprint import pprint
 
 from threading import local
 
@@ -67,6 +68,7 @@ def documents_from_file(es, filename, delimiter, quiet, csv_date_field, csv_date
 
                 # parse csv_date_field into elasticsearch compatible epoch_millis
                 if csv_date_field:
+                    pprint(row)
                     date_val_str = row[csv_date_field]
                     if date_val_str:
                         date_obj = parser.parse(date_val_str.strip())

--- a/csv2es.py
+++ b/csv2es.py
@@ -83,12 +83,9 @@ def documents_from_file(es, filename, delimiter, quiet, csv_clean_fieldnames, cs
 
                     if date_val_str:
                         date_obj = parser.parse(date_val_str.strip())
-                        pprint(date_obj)
                         corrected_offset = (csv_date_field_gmt_offset * -1)
                         date_obj = date_obj + timedelta(hours=corrected_offset)
-                        pprint(date_obj)
                         row[csv_date_field] = int(calendar.timegm(date_obj.timetuple())) * 1000
-                        pprint(row)
 
                 count += 1
                 if count % 10000 == 0:

--- a/csv2es.py
+++ b/csv2es.py
@@ -16,7 +16,6 @@ import csv
 import json
 import sys
 import calendar
-from pprint import pprint
 
 from threading import local
 


### PR DESCRIPTION
Adds the following options

```
  --csv-clean-fieldnames          Strips double quotes and lower-cases all CSV
                                  header names for proper ElasticSearch
                                  fieldnames
  --csv-date-field TEXT           The CSV header name that represents a date
                                  string to parsed (via python-dateutil) into
                                  an ElasticSearch epoch_millis
  --csv-date-field-gmt-offset INTEGER
                                  The GMT offset for the csv-date-field (i.e.
                                  +/- N hours)
  --tags TEXT                     Custom static key1=val1,key2=val2 pairs to
                                  tag all entries with
```